### PR TITLE
Ensure CI installs test dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install dependencies
-        run: pip install homeassistant pytest pytest-asyncio
+        run: pip install -e .[test]
       - name: Run tests
         run: |
           PYTHONPATH=. pytest custom_components/assist_traces/tests -q

--- a/custom_components/assist_traces/__init__.py
+++ b/custom_components/assist_traces/__init__.py
@@ -41,7 +41,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await async_setup_services(hass)
     await async_setup_ws(hass)
-    hass.config_entries.async_setup_platforms(entry, ["sensor"])
+    await hass.config_entries.async_setup_platforms(entry, ["sensor"])
     return True
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,6 @@ dependencies = [
 [project.optional-dependencies]
 test = [
   "homeassistant==2024.6.0",
+  "pytest",
   "pytest-asyncio",
 ]


### PR DESCRIPTION
## Summary
- Install package with test extras in CI to pull in project dependencies
- Declare pytest in the `test` optional dependency group
- Track correlator timeout tasks and await config entry platform setup to avoid unawaited coroutine warnings

## Testing
- `PYTHONTRACEMALLOC=1 PYTHONPATH=. pytest custom_components/assist_traces/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb9dad4aec8328a9d39598e0a6ec54