### PR TITLE
feat: trace text-based pipelines

### DIFF
--- a/custom_components/assist_traces/manifest.json
+++ b/custom_components/assist_traces/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "assist_traces",
     "name": "Assist Traces",
-    "version": "0.2.2",
+    "version": "0.3.0",
     "documentation": "https://example.com/assist_traces",
     "requirements": [
         "orjson>=3.10",

--- a/custom_components/assist_traces/pipeline.py
+++ b/custom_components/assist_traces/pipeline.py
@@ -12,7 +12,7 @@ from .const import DATA_TRACES, DATA_WRITER
 
 
 async def async_setup_pipeline_tracing(hass: HomeAssistant) -> None:
-    """Wrap assist pipeline to capture events for tracing."""
+    """Wrap Assist pipelines to capture events for tracing."""
     if getattr(
         assist_pipeline.async_pipeline_from_audio_stream,
         "_assist_traces_wrapped",
@@ -20,35 +20,42 @@ async def async_setup_pipeline_tracing(hass: HomeAssistant) -> None:
     ):
         return
 
-    original = assist_pipeline.async_pipeline_from_audio_stream
+    def _wrap(original):
+        """Wrap an Assist pipeline function to capture events."""
 
-    async def traced_async_pipeline_from_audio_stream(*args, event_callback, **kwargs):
-        """Capture pipeline events while delegating to the original implementation."""
-        trace: Dict[str, Any] = {"events": []}
-        trace_id = uuid.uuid4().hex
+        async def traced(*args, event_callback, **kwargs):
+            """Capture pipeline events while delegating to the original implementation."""
+            trace: Dict[str, Any] = {"events": []}
+            trace_id = uuid.uuid4().hex
 
-        def _capture(event: assist_pipeline.PipelineEvent) -> None:
-            """Store each pipeline event and dispatch to the original callback."""
-            trace.setdefault("ts", event.timestamp)
-            trace["events"].append(
-                {
-                    "type": event.type.value,
-                    "data": event.data,
-                    "timestamp": event.timestamp,
-                }
-            )
-            event_callback(event)
-            if event.type == assist_pipeline.PipelineEventType.RUN_END:
-                trace["trace_id"] = trace_id
-                trace.setdefault("model", "assist-pipeline")
-                hass.data[DATA_TRACES][trace_id] = trace
-                writer = hass.data.get(DATA_WRITER)
-                if writer is not None:
-                    hass.async_create_task(writer.enqueue(trace))
+            def _capture(event: assist_pipeline.PipelineEvent) -> None:
+                """Store each pipeline event and dispatch to the original callback."""
+                trace.setdefault("ts", event.timestamp)
+                trace["events"].append(
+                    {
+                        "type": event.type.value,
+                        "data": event.data,
+                        "timestamp": event.timestamp,
+                    }
+                )
+                event_callback(event)
+                if event.type == assist_pipeline.PipelineEventType.RUN_END:
+                    trace["trace_id"] = trace_id
+                    trace.setdefault("model", "assist-pipeline")
+                    hass.data[DATA_TRACES][trace_id] = trace
+                    writer = hass.data.get(DATA_WRITER)
+                    if writer is not None:
+                        hass.async_create_task(writer.enqueue(trace))
 
-        return await original(*args, event_callback=_capture, **kwargs)
+            return await original(*args, event_callback=_capture, **kwargs)
 
-    assist_pipeline.async_pipeline_from_audio_stream = (
-        traced_async_pipeline_from_audio_stream
+        traced._assist_traces_wrapped = True
+        return traced
+
+    assist_pipeline.async_pipeline_from_audio_stream = _wrap(
+        assist_pipeline.async_pipeline_from_audio_stream
     )
-    assist_pipeline.async_pipeline_from_audio_stream._assist_traces_wrapped = True
+    if hasattr(assist_pipeline, "async_pipeline_from_text"):
+        assist_pipeline.async_pipeline_from_text = _wrap(
+            assist_pipeline.async_pipeline_from_text
+        )

--- a/custom_components/assist_traces/tests/conftest.py
+++ b/custom_components/assist_traces/tests/conftest.py
@@ -19,6 +19,8 @@ hassil = types.ModuleType("hassil")
 hassil.__path__ = []  # type: ignore[attr-defined]
 expression = types.ModuleType("hassil.expression")
 intents = types.ModuleType("hassil.intents")
+recognize = types.ModuleType("hassil.recognize")
+util = types.ModuleType("hassil.util")
 
 
 class Expression:  # noqa: D401
@@ -59,6 +61,20 @@ intents.WildcardSlotList = WildcardSlotList
 sys.modules.setdefault("hassil", hassil)
 sys.modules.setdefault("hassil.expression", expression)
 sys.modules.setdefault("hassil.intents", intents)
+recognize.MISSING_ENTITY = None
+recognize.RecognizeResult = object
+recognize.UnmatchedTextEntity = object
+recognize.UnmatchedRangeEntity = object
+recognize.recognize_all = lambda *args, **kwargs: []
+recognize.PUNCTUATION = ""
+sys.modules.setdefault("hassil.recognize", recognize)
+util.merge_dict = lambda a, b: {**a, **b}
+sys.modules.setdefault("hassil.util", util)
+home_assistant_intents = types.ModuleType("home_assistant_intents")
+home_assistant_intents.ErrorKey = object
+home_assistant_intents.get_intents = lambda *args, **kwargs: {}
+home_assistant_intents.get_languages = lambda: []
+sys.modules.setdefault("home_assistant_intents", home_assistant_intents)
 
 
 @pytest.fixture

--- a/custom_components/assist_traces/tests/test_pipeline.py
+++ b/custom_components/assist_traces/tests/test_pipeline.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import enum
+import importlib
+import sys
+import types
+from dataclasses import dataclass
+
+import pytest
+
+from custom_components.assist_traces.const import DATA_TRACES
+
+
+@pytest.mark.asyncio
+async def test_pipeline_from_text_traced(hass):
+    """Ensure text pipelines are traced and events stored."""
+
+    class PipelineEventType(enum.Enum):
+        RUN_END = "run-end"
+
+    @dataclass
+    class PipelineEvent:
+        type: PipelineEventType
+        data: dict | None = None
+        timestamp: str = "2024-06-01T00:00:00"
+
+    async def fake_pipeline(*args, event_callback, **kwargs):
+        event_callback(PipelineEvent(PipelineEventType.RUN_END, {"result": "ok"}))
+        return "done"
+
+    assist_pipeline = types.SimpleNamespace(
+        async_pipeline_from_audio_stream=fake_pipeline,
+        async_pipeline_from_text=fake_pipeline,
+        PipelineEvent=PipelineEvent,
+        PipelineEventType=PipelineEventType,
+    )
+    components = types.SimpleNamespace(assist_pipeline=assist_pipeline)
+    sys.modules["homeassistant.components"] = components
+    sys.modules["homeassistant.components.assist_pipeline"] = assist_pipeline
+
+    pipeline_module = importlib.import_module(
+        "custom_components.assist_traces.pipeline"
+    )
+
+    hass.data[DATA_TRACES] = {}
+    await pipeline_module.async_setup_pipeline_tracing(hass)
+    result = await assist_pipeline.async_pipeline_from_text(
+        hass, event_callback=lambda e: None
+    )
+
+    assert result == "done"
+    assert len(hass.data[DATA_TRACES]) == 1
+    trace = next(iter(hass.data[DATA_TRACES].values()))
+    assert trace["events"][0]["data"] == {"result": "ok"}
+    assert trace["events"][0]["type"] == PipelineEventType.RUN_END.value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 88
 
 [project]
 name = "assist-traces"
-version = "0.2.2"
+version = "0.3.0"
 requires-python = ">=3.11"
 dependencies = [
   "pydantic>=2.7",


### PR DESCRIPTION
## Summary
- wrap Assist pipelines started from text to capture events
- bump version to 0.3.0
- add tests for tracing pipelines from text

## Testing
- `ruff format .`
- `ruff check .`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_68bbbe99019483288f33973ff529d456