### PR TITLE
fix: replace deprecated platform setup

### DIFF
--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,0 +1,1 @@
+"""Custom components namespace for Assist Traces tests."""

--- a/custom_components/assist_traces/__init__.py
+++ b/custom_components/assist_traces/__init__.py
@@ -44,12 +44,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await async_setup_pipeline_tracing(hass)
     await async_setup_services(hass)
     await async_setup_ws(hass)
-    await hass.config_entries.async_setup_platforms(entry, ["sensor"])
+    await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload assist_traces config entry."""
     await hass.data[DATA_WRITER].stop()
-    await hass.config_entries.async_unload_platforms(entry, ["sensor"])
-    return True
+    return await hass.config_entries.async_unload_platforms(entry, ["sensor"])

--- a/custom_components/assist_traces/manifest.json
+++ b/custom_components/assist_traces/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "assist_traces",
     "name": "Assist Traces",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "documentation": "https://example.com/assist_traces",
     "requirements": [
         "orjson>=3.10",

--- a/custom_components/assist_traces/tests/conftest.py
+++ b/custom_components/assist_traces/tests/conftest.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import pytest
 import sys
 import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from homeassistant.core import HomeAssistant
 import pytest_asyncio
@@ -91,8 +94,8 @@ def event_loop():
 class MockConfigEntries:
     """Minimal stand-in for Home Assistant's config entries manager."""
 
-    async def async_setup_platforms(self, entry, platforms):
-        """Pretend to set up platforms for the given entry."""
+    async def async_forward_entry_setups(self, entry, platforms):
+        """Pretend to forward setups for the given entry."""
         return True
 
     async def async_unload_platforms(self, entry, platforms):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 88
 
 [project]
 name = "assist-traces"
-version = "0.3.2"
+version = "0.3.3"
 requires-python = ">=3.11"
 dependencies = [
   "pydantic>=2.7",


### PR DESCRIPTION
## Summary
- replace deprecated `async_setup_platforms` with `async_forward_entry_setups`
- return result from unload helper
- bump version to 0.3.3
- adjust tests for new config entries API

## Testing
- `ruff format .`
- `ruff check .`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_68bbcd83b9a88328b3dc881a8702311b